### PR TITLE
Update creating-a-default-community-health-file.md

### DIFF
--- a/content/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file.md
+++ b/content/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file.md
@@ -42,7 +42,7 @@ Issue and pull request templates{% ifversion fpt or ghes or ghec %} and _config.
 `SECURITY.md` | A SECURITY file gives instructions for how to report a security vulnerability in your project. For more information, see "[AUTOTITLE](/code-security/getting-started/adding-a-security-policy-to-your-repository)."{% endif %}
 _SUPPORT.md_ | A SUPPORT file lets people know about ways to get help with your project. For more information, see "[AUTOTITLE](/communities/setting-up-your-project-for-healthy-contributions/adding-support-resources-to-your-project)."
 
-You cannot create a default license file. License files must be added to individual repositories so the file will be included when a project is cloned, packaged, or downloaded.
+You cannot create a default LICENSE file or a CODEOWNERS file. These files must be added to individual repositories so the file will be included when a project is cloned, packaged, or downloaded.
 
 ## Creating a repository for default files
 


### PR DESCRIPTION
### Why

The fact that a `CODEOWNERS` file cannot be added to the `.github` repository is missing.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

I added the fact that a `CODEOWNERS` file cannot be added to the `.github` repository.

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
